### PR TITLE
Statistics Sync fixes for review

### DIFF
--- a/src/main/java/hd/sphinx/sync/mysql/ManageMySQLData.java
+++ b/src/main/java/hd/sphinx/sync/mysql/ManageMySQLData.java
@@ -144,7 +144,10 @@ public class ManageMySQLData {
                         syncProfile.setRawStatistics(StatisticsManager.loadPlayerStatistics(player, result));
                     }
                 } catch (Exception ignored) { }
-                player.sendMessage(ConfigManager.getColoredString("messages.loaded"));
+                String generatedMessage = ConfigManager.getColoredString("messages.loaded");
+                if (!generatedMessage.trim().isEmpty()) {
+                    player.sendMessage(generatedMessage);
+                }
             }
             Main.schedulerManager.getScheduler().scheduleExecuteCommands(player);
             Main.schedulerManager.getScheduler().scheduleCompleteLoadEvent(player, syncProfile);

--- a/src/main/java/hd/sphinx/sync/util/StatisticsManager.java
+++ b/src/main/java/hd/sphinx/sync/util/StatisticsManager.java
@@ -33,14 +33,25 @@ public class StatisticsManager {
         String drop = Statistic.DROP.toString();
         String pickup = Statistic.PICKUP.toString();
         for (Material material : Material.values()) {
+            // MINE_BLOCK only for blocks
             if (material.isBlock()) {
-                returnHashMap.put(material.toString() + "==/=" + mineBlock, player.getStatistic(Statistic.MINE_BLOCK, material));
+                try {
+                    returnHashMap.put(material + "==/=" + mineBlock, player.getStatistic(Statistic.MINE_BLOCK, material));
+                } catch (IllegalArgumentException ignored) {}
             }
-            returnHashMap.put(material.toString() + "==/=" + useItem, player.getStatistic(Statistic.USE_ITEM, material));
-            returnHashMap.put(material.toString() + "==/=" + breakItem, player.getStatistic(Statistic.BREAK_ITEM, material));
-            returnHashMap.put(material.toString() + "==/=" + craftItem, player.getStatistic(Statistic.CRAFT_ITEM, material));
-            returnHashMap.put(material.toString() + "==/=" + drop, player.getStatistic(Statistic.DROP, material));
-            returnHashMap.put(material.toString() + "==/=" + pickup, player.getStatistic(Statistic.PICKUP, material));
+
+            // The following stats must only be called for items
+            if (!material.isItem()) continue;
+
+            try {
+                returnHashMap.put(material + "==/=" + useItem, player.getStatistic(Statistic.USE_ITEM, material));
+                returnHashMap.put(material + "==/=" + breakItem, player.getStatistic(Statistic.BREAK_ITEM, material));
+                returnHashMap.put(material + "==/=" + craftItem, player.getStatistic(Statistic.CRAFT_ITEM, material));
+                returnHashMap.put(material + "==/=" + drop, player.getStatistic(Statistic.DROP, material));
+                returnHashMap.put(material + "==/=" + pickup, player.getStatistic(Statistic.PICKUP, material));
+            } catch (IllegalArgumentException ignored) {
+                // Skip invalid materials
+            }
         }
 
         String killEntity = Statistic.KILL_ENTITY.toString();
@@ -66,16 +77,52 @@ public class StatisticsManager {
         }
 
         for (String statistic : statistics.keySet()) {
-            if (statistic.contains("==/=") && statistic.contains("entity")) {
+            int value = statistics.get(statistic);
+
+            if (statistic.contains("==/=")) {
                 String[] statisticArray = statistic.split("==/=");
-                player.setStatistic(Statistic.valueOf(statisticArray[1]), EntityType.valueOf(statisticArray[0]), statistics.get(statistic));
-            } else if (statistic.contains("==/=")) {
-                String[] statisticArray = statistic.split("==/=");
-                player.setStatistic(Statistic.valueOf(statisticArray[1]), Material.valueOf(statisticArray[0]), statistics.get(statistic));
+                String key = statisticArray[0];
+                String statName = statisticArray[1];
+
+                try {
+                    Statistic stat = Statistic.valueOf(statName);
+
+                    if (isEntityStatistic(stat)) {
+                        // Handle Entity statistics
+                        try {
+                            EntityType entityType = EntityType.valueOf(key);
+                            player.setStatistic(stat, entityType, value);
+                        } catch (IllegalArgumentException ignored) { }
+                    } else {
+                        // Handle Material statistics
+                        try {
+                            Material material = Material.valueOf(key);
+                            // Only set item stats for real items
+                            if (requiresItemStatistic(stat) && !material.isItem()) continue;
+                            player.setStatistic(stat, material, value);
+                        } catch (IllegalArgumentException ignored) { }
+                    }
+                } catch (IllegalArgumentException ignored) { }
             } else {
-                player.setStatistic(Statistic.valueOf(statistic), statistics.get(statistic));
+                // Handle simple statistics
+                try {
+                    player.setStatistic(Statistic.valueOf(statistic), value);
+                } catch (IllegalArgumentException ignored) { }
             }
         }
+
         return statistics;
+    }
+
+    private static boolean isEntityStatistic(Statistic stat) {
+        return stat == Statistic.KILL_ENTITY || stat == Statistic.ENTITY_KILLED_BY;
+    }
+
+    private static boolean requiresItemStatistic(Statistic stat) {
+        return stat == Statistic.USE_ITEM ||
+                stat == Statistic.BREAK_ITEM ||
+                stat == Statistic.CRAFT_ITEM ||
+                stat == Statistic.DROP ||
+                stat == Statistic.PICKUP;
     }
 }


### PR DESCRIPTION
Hey! It's my first time doing something like this but this plugin is very helpful for my server and I just wanted others to have an alternative to the currently broken husky sync statistics sync, I installed the compiled plugin on both my backend servers and gave it a database to connect to and it was able to sync statistics across servers (statistics was the only thing I had selected in the config).
Here's a list of changes:
1. Filtered blocks from item statistics in order to support 1.20+ (I was getting enum class exceptions for wall hanging signs)
2. Adjusted load player statistics for above changes and handling 1.20+
3. Reversed JoinListener logic so players who have finished loading are given the ok (This fixed the account generation bug I had where we were unable to do anything until I rejoined and was given the flag, but I understand if you hate this change)
4. Any time the plugin prints a message to the player if the lang slot is empty it wont print an annoying space in chat (I kept the error calls unchanged since those are needed)

And that's about it, please let me know what you think, I hope this isn't a pain just wanted to shoot my thoughts. (I now understand the pain of syncing statistics)